### PR TITLE
feat: Implement favourite quotes API endpoints

### DIFF
--- a/server/controllers/userControllers.js
+++ b/server/controllers/userControllers.js
@@ -1,0 +1,75 @@
+const User = require('../models/User.js');
+const Quote = require('../models/Quote.js')
+const mongoose = require('mongoose')
+const asyncHandler = require('../utils/asyncHandler.js')
+
+
+/*****************************
+@desc    Add a quote to user's favorites
+@route POST /api/user/profile/favorites
+@access private/protected
+*****************************/
+const addFavoriteQuote = asyncHandler(async (req,res)=>{
+    const {quoteId} = req.body;
+    const userId = req.user._id;
+    if(!quoteId){
+        res.status(400)
+        throw new Error('Quote Id is required');
+    }
+    const quoteExists = await Quote.findById(quoteId)
+    if(!quoteExists){
+        res.status(404)
+        throw new Error("Quote not found.");
+    }
+    await User.findByIdAndUpdate(userId,{$addToSet:{'favoriteQuotes':quoteId}})
+    res.status(200).json({
+        success:true,
+        message:"Quote added to favorites."
+    })
+})
+
+/*****************************
+@desc get user's favorite quotes
+@route GET /api/user/profile/favorites
+@access private/protected
+*****************************/
+const getFavoriteQuotes = asyncHandler(async(req,res)=>{
+    const userId = req.user._id;
+    const user = await User.findById(userId).populate("favoriteQuotes")
+    if(!user){
+        res.status(404)
+        throw new Error("User not found.")
+    }
+    res.status(200).json({
+        success:true,
+        message:"User's favorite quote reterived successfully",
+        favoriteQuotes: user.favoriteQuotes
+    })
+})
+/*****************************
+@desc remove a quote from user's favorite
+@route Delete /api/user/profile/favorites/:quoteId
+@access private/protected
+*****************************/
+const removeFavoriteQuote= asyncHandler(async(req,res)=>{
+    const {quoteId} = req.params
+    const userId = req.user._id
+        if (!mongoose.Types.ObjectId.isValid(quoteId)) {
+        return res.status(400).json({
+            success: false,
+            message: "Invalid Quote ID."
+        });
+    }
+    await User.findByIdAndUpdate(userId,{$pull:{'favoriteQuotes':quoteId}})
+    res.status(200).json({
+        success:true,
+        message:"Removed from the favorite list."
+
+    })
+})
+
+module.exports = {
+    addFavoriteQuote,
+    getFavoriteQuotes,
+    removeFavoriteQuote
+}

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -2,8 +2,6 @@ const express = require('express')
 const {registerUser,loginUser} = require('../controllers/authControllers')
 const router = express.Router()
 
-router.route('/register').post(registerUser).get((req,res)=>{
-    console.log("i'm response")
-})
+router.route('/register').post(registerUser)
 router.route('/login').post(loginUser)
 module.exports = router

--- a/server/routes/userRoutes.js
+++ b/server/routes/userRoutes.js
@@ -1,10 +1,9 @@
-const express = require('express')
+const express = require("express");
 const router = express.Router();
-const {protect} = require('../middlewares/authMiddleware')
+const { protect } = require("../middlewares/authMiddleware.js");
+const { addFavoriteQuote,getFavoriteQuotes,removeFavoriteQuote} = require("../controllers/userControllers.js");
+router.use(protect);
+router.route("/profile/favorites").post(addFavoriteQuote).get(getFavoriteQuotes);
+router.route("/profile/favorites/:quoteId").delete(removeFavoriteQuote)
 
-    router.route('/profile').get(protect,(req,res)=>{
-        console.log(req.user)
-        res.send("im check the authWork or not",req.body || "undefined")
-    })
-
-module.exports = router    
+module.exports = router;


### PR DESCRIPTION

This pull request implements the full backend functionality for managing a user's **favorite quotes**. It adds protected API endpoints that allow a logged-in user to add, view, and remove quotes from their personal favorites list.

### Key Features Implemented:

* **`POST /api/users/profile/favorites`**: Adds a specified quote to the user's favorites list. Uses `$addToSet` to prevent duplicates.
* **`GET /api/users/profile/favorites`**: Retrieves a list of the user's favorite quotes, populating the full quote details.
* **`DELETE /api/users/profile/favorites/:quoteId`**: Removes a specific quote from the user's favorites list using `$pull`.

All endpoints are protected by the `authMiddleware` and are associated with the authenticated user. This completes the core API for the quote feature.