### PR TITLE
feat: Implement pagination for quotes API and frontend

### DIFF
--- a/client/src/services/quoteService.ts
+++ b/client/src/services/quoteService.ts
@@ -16,8 +16,8 @@ export const UserFavoriteQuotes = async () => {
     }
     return response.json();
 }
-export const getQuotes = async ()=>{
-    const response = await fetch('/api/quotes',{
+export const getQuotes = async ({limit,page}:{limit:number|undefined , page:number|undefined})=>{
+    const response = await fetch(`/api/quotes?limit=${limit}&page=${page}`,{
         method:'GET',
         headers:{
             'Content-Type':'application/json'

--- a/server/controllers/quoteControllers.js
+++ b/server/controllers/quoteControllers.js
@@ -1,5 +1,5 @@
-const asyncHandler = require('../utils/asyncHandler.js')
-const Quote = require('../models/Quote.js')
+const asyncHandler = require("../utils/asyncHandler.js");
+const Quote = require("../models/Quote.js");
 
 // first for those controllers which can be seen with the non logged in users too.
 
@@ -8,37 +8,67 @@ const Quote = require('../models/Quote.js')
 @route GET /api/quotes
 @access public
 *****************************/
-const getQuotes = asyncHandler(async (req,res)=>{
-    const quotes = await Quote.find({});
-    res.status(200).json({
-        success: true,
-        count: quotes.length,
-        message: "Quotes retrieved successfully.",
-        quotes: quotes
-    })
-})
+const getQuotes = asyncHandler(async (req, res) => {
+  // pagesize or limit : how many data wants as the response
+  // page : this will carry the page number
+  // offset is the value we are going calculate which gives data needs to be ignore
+  // offset = (page - 1) * pageSize
+  // this is the page-based api pagination first need to sort the documents so the ignored data will not be reoccured
+
+  const pagesize = parseInt(req.query.limit) || 30;
+  const page = parseInt(req.query.page) || 1;
+  const offSet = (page-1)*pagesize;
+  const result = await Quote.aggregate([
+    {$sort:{_id:1}},
+    {
+        $facet:{
+            metadata:[{$count:"total"}],
+            data:[
+                {$skip:offSet},
+                {$limit:pagesize}
+            ]
+        }
+    }
+]);
+const quotes = result[0].data;
+const totalCount = result[0].metadata ? result[0].metadata[0].total : 0;
+const totalPages = Math.ceil(totalCount/pagesize); 
+  res.status(200).json({
+    success: true,
+    count: quotes.length,
+    message: "Quotes retrieved successfully.",
+    quotes: quotes,
+    pagination:{
+        'current-page':page,
+        'limit': pagesize,
+        'totalQuotes': totalCount,
+        'totalPages' : totalPages,
+        'nextPage':`api/quotes?limit=${pagesize}&page=${page+1}`
+    }
+  });
+});
 /*****************************
 @desc create the getRandomQuotes for the non logged in users
 @route GET /api/quotes/random
 @access public
 *****************************/
 
-const getRandomQuotes = asyncHandler(async (req,res)=>{
-        const randomQuote = await Quote.aggregate([{$sample:{size: 1}}]);
-    if(!randomQuote || randomQuote.length === 0){
-        return res.status(404).json({
-            success: false,
-            message : "No Quote available in the database."
-        })
-    }
-        res.status(200).json({
-        success: true,
-        message: "Random quote Retrieved Successfully",
-        quote: randomQuote[0]
-    })
-})
+const getRandomQuotes = asyncHandler(async (req, res) => {
+  const randomQuote = await Quote.aggregate([{ $sample: { size: 1 } }]);
+  if (!randomQuote || randomQuote.length === 0) {
+    return res.status(404).json({
+      success: false,
+      message: "No Quote available in the database.",
+    });
+  }
+  res.status(200).json({
+    success: true,
+    message: "Random quote Retrieved Successfully",
+    quote: randomQuote[0],
+  });
+});
 
-module.exports ={
-    getQuotes,
-    getRandomQuotes
-}
+module.exports = {
+  getQuotes,
+  getRandomQuotes,
+};

--- a/server/models/Quote.js
+++ b/server/models/Quote.js
@@ -30,7 +30,7 @@ const quoteSchema = new mongoose.Schema({
 }
 
 },{timestamps: true})
-quoteSchema.index({quoteText:1,category:1},{unique: true})
+quoteSchema.index({quoteText:1},{unique: true})
 const Quote = mongoose.model("Quote",quoteSchema)
 
 module.exports = Quote;


### PR DESCRIPTION
# feat: Implement pagination for quotes API and frontend

### Summary

This pull request introduces full pagination functionality for the quotes feature. It includes backend API support for page and limit parameters and a responsive frontend interface to navigate through the paginated results.

### Implementation Details

**Backend:**
- The `GET /api/quotes` endpoint now accepts `page` and `limit` query parameters to serve paginated data.
- Uses an efficient aggregation pipeline with `$facet` to fetch quote data and total count in a single query.
- The API response includes a `pagination` object with `currentPage`, `totalPages`, and `totalQuotes` for frontend use.

**Frontend:**
- Added state management to track the current page and limit.
- Implemented "Previous" and "Next" buttons that dynamically fetch and render the corresponding page of quotes.
- The header and tabs are now sticky for a better user experience on scroll.
- Ensured that favorited quotes retain their correct status when navigating between pages.
